### PR TITLE
Add OTEL integration via Jaeger

### DIFF
--- a/integrations/nginx/config.json
+++ b/integrations/nginx/config.json
@@ -3,8 +3,8 @@
   "version": {
     "integ": "0.1.0",
     "schema": "1.0.0",
-    "resource": "^1.23.0",
-  }
+    "resource": "^1.23.0"
+  },
   "description": "Nginx HTTP server collector",
   "categories": [
     "web","http"

--- a/integrations/nginx/test/docker-compose.yaml
+++ b/integrations/nginx/test/docker-compose.yaml
@@ -1,0 +1,49 @@
+version: '3'
+
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.5.0
+    container_name: opensearch
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+    ports:
+      - 9200:9200
+      - 9600:9600
+    networks:
+      - www
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: jaeger
+    environment:
+      - SPAN_STORAGE_TYPE=opensearch
+    command: [
+      "--es.server-urls=http://opensearch:9200"
+    ]
+    restart: on-failure
+    ports:
+      - 16686:16686
+    networks:
+      - www
+  collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=/etc/volume/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector:/etc/volume
+    ports:
+      - 4317:4317
+    networks:
+      - www
+  nginx:
+    image: nginx-otel
+    build:
+      context: nginx-otel
+    volumes:
+      - ./nginx-otel/opentelemetry_module.conf:/etc/nginx/conf.d/opentelemetry_module.conf
+    ports:
+      - 8080:80
+    networks:
+      - www
+
+networks:
+  www:

--- a/integrations/nginx/test/nginx-otel/Dockerfile
+++ b/integrations/nginx/test/nginx-otel/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.18
+RUN apt-get update ; apt-get install unzip
+ADD https://github.com/open-telemetry/opentelemetry-cpp-contrib/releases/download/webserver%2Fv1.0.0/opentelemetry-webserver-sdk-x64-linux.tgz.zip /opt
+RUN cd /opt ; unzip opentelemetry-webserver-sdk-x64-linux.tgz.zip; tar xvfz opentelemetry-webserver-sdk-x64-linux.tgz
+RUN cd /opt/opentelemetry-webserver-sdk; ./install.sh
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/opentelemetry-webserver-sdk/sdk_lib/lib
+RUN echo "load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/ngx_http_opentelemetry_module.so;\n$(cat /etc/nginx/nginx.conf)" > /etc/nginx/nginx.conf
+COPY opentelemetry_module.conf /etc/nginx/conf.d

--- a/integrations/nginx/test/nginx-otel/opentelemetry_module.conf
+++ b/integrations/nginx/test/nginx-otel/opentelemetry_module.conf
@@ -1,0 +1,8 @@
+NginxModuleEnabled ON;
+NginxModuleOtelSpanExporter otlp;
+NginxModuleOtelExporterEndpoint collector:4317;
+NginxModuleServiceName DemoService;
+NginxModuleServiceNamespace DemoServiceNamespace;
+NginxModuleServiceInstanceId DemoInstanceId;
+NginxModuleResolveBackends ON;
+NginxModuleTraceAsError ON;

--- a/integrations/nginx/test/otel-collector/otel-collector-config.yaml
+++ b/integrations/nginx/test/otel-collector/otel-collector-config.yaml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  file:
+    path: /etc/volume/log.json
+  jaeger:
+    endpoint: jaeger:14250
+    tls:
+      insecure: true
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [file, jaeger]


### PR DESCRIPTION
Set up so that when the compose is built and ran, getting from `localhost:8080` routes to the opensearch image. The documents are accessible at the `jaeger-span-YYYY-MM-DD` index. Flow: nginx -> otel collector -> jaeger -> opensearch.